### PR TITLE
Add Overlayfs Functionality

### DIFF
--- a/cmd/inito/main.go
+++ b/cmd/inito/main.go
@@ -57,7 +57,7 @@ func main() {
 		},
 		{
 			Cmd:  "/bbin/modprobe",
-			Args: []string{"modprobe", "-a", "virtio_net", "virtio-rng", "virtio_blk", "af_packet", "rbd"},
+			Args: []string{"modprobe", "-a", "virtio_net", "virtio-rng", "virtio_blk", "af_packet", "rbd", "squashfs", "overlay"},
 		},
 		{
 			Cmd:  "/bbin/dhclient",

--- a/cmd/inito/main.go
+++ b/cmd/inito/main.go
@@ -16,6 +16,8 @@ import (
 	"os/exec"
 	"strconv"
 	"syscall"
+
+	"github.com/bensallen/rbd/pkg/mount"
 )
 
 // info about background processes, inclding std{out,in,err} will be placed here
@@ -65,9 +67,17 @@ func main() {
 		},
 		{
 			Cmd:  "/bbin/rbd",
-			Args: []string{"/bbin/rbd", "--verbose", "boot", "--mkdir", "--switch-root"},
+			Args: []string{"/bbin/rbd", "--verbose", "boot", "--mkdir", "--switch-root=/sbin/init"},
 			Exec: true,
 		},
+	}
+
+	if err := os.MkdirAll("/run", 0755); err != nil {
+		log.Println(err)
+	}
+
+	if err := mount.Mount("tmpfs", "/run", "tmpfs", []string{"rw", "nosuid", "nodev", "mode=755"}); err != nil {
+		log.Println(err)
 	}
 
 	envs := os.Environ()

--- a/internal/cli/boot/boot.go
+++ b/internal/cli/boot/boot.go
@@ -98,11 +98,24 @@ func Run(args []string, verbose bool, noop bool) error {
 				return err
 			}
 		}
-		if *switchRoot {
-			if root, ok := mounts["root"]; ok {
-				if verbose {
-					log.Printf("Boot: attempting to switch root to %s with /sbin/init\n", root.Path)
+	}
+
+	if root, ok := mounts["root"]; ok {
+		if root.Overlay {
+			if verbose {
+				log.Printf("Boot: attempting to mount overlay over %s\n", root.Path)
+			}
+			if !noop {
+				if err := mount.Overlay(root.Path); err != nil {
+					return err
 				}
+			}
+		}
+		if *switchRoot {
+			if verbose {
+				log.Printf("Boot: attempting to switch root to %s with /sbin/init\n", root.Path)
+			}
+			if !noop {
 				return mount.SwitchRoot(root.Path, "/sbin/init")
 			}
 		}

--- a/pkg/cmdline/cmdline_test.go
+++ b/pkg/cmdline/cmdline_test.go
@@ -87,8 +87,8 @@ func TestParse(t *testing.T) {
 	}{
 		{
 			name: "rbd.root=",
-			args: args{cmdline: `rbd={"root": {"image":{"mons": ["192.168.0.1","192.168.0.2","192.168.0.3:6789"], "opts":{"name": "admin", "secret": "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q=="}, "pool":"rbd", "image":"test-image1"}, "path":"/newroot", "fstype":"ext4", "overlay": true}}`},
-			want: map[string]*Mount{"root": {Image: &krbd.Image{Monitors: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3:6789"}, Options: &krbd.Options{Name: "admin", Secret: "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q=="}, Pool: "rbd", Image: "test-image1"}, Path: "/newroot", FsType: "ext4", Overlay: true}},
+			args: args{cmdline: `rbd={"root": {"image":{"mons": ["192.168.0.1","192.168.0.2","192.168.0.3:6789"], "opts":{"name": "admin", "secret": "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q==", "readonly": true}, "pool":"rbd", "image":"test-image1"}, "path":"/newroot", "fstype":"ext4", "overlay": true}}`},
+			want: map[string]*Mount{"root": {Image: &krbd.Image{Monitors: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3:6789"}, Options: &krbd.Options{Name: "admin", Secret: "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q==", ReadOnly: true}, Pool: "rbd", Image: "test-image1"}, Path: "/newroot", FsType: "ext4", Overlay: true}},
 		},
 		{
 			name: "rbd.root= specified twice with different attributes",

--- a/pkg/cmdline/cmdline_test.go
+++ b/pkg/cmdline/cmdline_test.go
@@ -87,8 +87,8 @@ func TestParse(t *testing.T) {
 	}{
 		{
 			name: "rbd.root=",
-			args: args{cmdline: `rbd={"root": {"image":{"mons": ["192.168.0.1","192.168.0.2","192.168.0.3:6789"], "opts":{"name": "admin", "secret": "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q=="}, "pool":"rbd", "image":"test-image1"}, "path":"/newroot", "fstype":"ext4"}}`},
-			want: map[string]*Mount{"root": {Image: &krbd.Image{Monitors: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3:6789"}, Options: &krbd.Options{Name: "admin", Secret: "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q=="}, Pool: "rbd", Image: "test-image1"}, Path: "/newroot", FsType: "ext4"}},
+			args: args{cmdline: `rbd={"root": {"image":{"mons": ["192.168.0.1","192.168.0.2","192.168.0.3:6789"], "opts":{"name": "admin", "secret": "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q=="}, "pool":"rbd", "image":"test-image1"}, "path":"/newroot", "fstype":"ext4", "overlay": true}}`},
+			want: map[string]*Mount{"root": {Image: &krbd.Image{Monitors: []string{"192.168.0.1", "192.168.0.2", "192.168.0.3:6789"}, Options: &krbd.Options{Name: "admin", Secret: "AQAvjX9eabfZAhAAj/g5nXSe/uaemYGCu1w53Q=="}, Pool: "rbd", Image: "test-image1"}, Path: "/newroot", FsType: "ext4", Overlay: true}},
 		},
 		{
 			name: "rbd.root= specified twice with different attributes",

--- a/pkg/mount/overlay.go
+++ b/pkg/mount/overlay.go
@@ -1,0 +1,26 @@
+package mount
+
+import (
+	"os"
+)
+
+// Overlay prepares and mounts a R/W overlay over the provided path. Mounts /run as a tmpfs and uses
+// /run/overlayfs/rw as the upper and /run/overlayfs/work as the workdir.
+func Overlay(path string) error {
+	if err := os.MkdirAll("/run", 0755); err != nil {
+		return err
+	}
+
+	if err := Mount("tmpfs", "/run", "tmpfs", []string{"rw", "nosuid", "nodev", "mode=755"}); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll("/run/overlayfs/rw", 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll("/run/overlayfs/work", 0755); err != nil {
+		return err
+	}
+
+	return Mount("overlay", "/newroot", "overlay", []string{"lowerdir=" + path, "upperdir=/run/overlayfs/rw", "workdir=/run/overlayfs/work"})
+}


### PR DESCRIPTION
- Add readonly rbd option into the test
- Add cli arg to boot to specify path of the switch_root init, standardize on /newroot as the root mount point, standardize on /run/overlay/lower as the root mount point if overlay is enabled for root.
- Add overlayfs functionality to add a R/W layer on top of a R/O remote RBD 