### PR TITLE
Load the af_packet kernel module as it appears Suse's kernel doesn't …

### DIFF
--- a/cmd/uinit/uinit.go
+++ b/cmd/uinit/uinit.go
@@ -1,10 +1,19 @@
-/* uinit.go: a simple init launcher for kraken layer0
+/* uinit.go: a simple init launcher
+ * Work based on https://github.com/hpc/kraken/blob/master/utils/layer0/uinit/uinit.go
  *
  * Author: J. Lowell Wofford <lowell@lanl.gov>
+ * Author: Benjamin S. Allen <bsallen@alcf.anl.gov>
  *
  * This software is open source software available under the BSD-3 license.
  * Copyright (c) 2018, Triad National Security, LLC
+ * Copyright (c) 2020, Benjamin S. Allen
  * See LICENSE file for details.
+ */
+
+/* For switch_root'ing to systemd, u-root's init has special casing.
+ * This app needs to be added into the u-root initramfs as /inito and
+ * the kernel cmdline uroot.initflags="systemd" needs to be used
+ * see https://github.com/u-root/u-root/blob/master/cmds/core/init/init_linux.go#L81
  */
 
 package main
@@ -63,7 +72,7 @@ func main() {
 		},
 		{
 			Cmd:  "/bbin/modprobe",
-			Args: []string{"modprobe", "-a", "rbd", "squashfs", "overlay"},
+			Args: []string{"modprobe", "-a", "rbd", "squashfs", "overlay", "af_packet"},
 		},
 		{
 			Cmd:  "/bbin/dhclient",


### PR DESCRIPTION
It appears Suse's kernel doesn't compile af_packet as a builtin so dhclient fails.

 Also added notes for how this uinit needs to be used with u-root when switch_rooting to systemd, as it needs to use the special casing to ensure its exec'ed as pid 1.