### PR TITLE
Add container unshare capabilities - Fixup

### DIFF
--- a/cmd/rbd/rbd.go
+++ b/cmd/rbd/rbd.go
@@ -5,9 +5,11 @@ import (
 	"os"
 
 	"github.com/bensallen/rbd/internal/cli/root"
+	"github.com/bensallen/rbd/pkg/boot"
 )
 
 func main() {
+	boot.PIDInit()
 	if err := root.Run(os.Args[1:]); err != nil {
 		fmt.Printf("Error: %v\n\n", err)
 		os.Exit(1)

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -49,6 +50,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-tpm v0.1.2-0.20190725015402-ae6dd98980d4/go.mod h1:H9HbmUG2YgV/PHITkO7p6wxEEj/v5nlsVWIwumwH2NI=
 github.com/google/go-tpm v0.2.1-0.20200615092505-5d8a91de9ae3/go.mod h1:iVLWvrPp/bHeEkxTFi9WG6K9w0iy2yIszHwZGHPbzAw=
@@ -134,8 +136,6 @@ github.com/u-root/iscsinl v0.1.0/go.mod h1:UGTrNqGTX3vAz6y/VmHC7pY8FLqoigybttGad
 github.com/u-root/u-root v1.0.1-0.20201119150355-04f343dd1922 h1:t9B62nb5RYgZNwrK+gaF//CDcJnYSt1HqE+MAROggM0=
 github.com/u-root/u-root v1.0.1-0.20201119150355-04f343dd1922/go.mod h1:c7G35Qvc1z58PWx/p1R9ROyiSuBc0ckqMU74klQ5g/s=
 github.com/u-root/u-root v6.0.1-0.20200118052101-6bcd1cda5996+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
-github.com/u-root/u-root v7.0.0+incompatible h1:u+KSS04pSxJGI5E7WE4Bs9+Zd75QjFv+REkjy/aoAc8=
-github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=

--- a/internal/cli/boot/boot.go
+++ b/internal/cli/boot/boot.go
@@ -148,7 +148,7 @@ func Run(args []string, verbose bool, noop bool) error {
 		}
 		if *unshareRoot != "" {
 			if verbose {
-
+				log.Printf("Boot: attempting to execute init in a namespaced context %s with init %s\n", RootPath, *unshareRoot)
 			}
 			if !noop {
 				return boot.UnshareRoot(RootPath, *unshareRoot)

--- a/internal/cli/boot/boot.go
+++ b/internal/cli/boot/boot.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing/iotest"
 
+	"github.com/bensallen/rbd/pkg/boot"
 	"github.com/bensallen/rbd/pkg/cmdline"
 	"github.com/bensallen/rbd/pkg/krbd"
 	"github.com/bensallen/rbd/pkg/mount"
@@ -21,10 +22,11 @@ Flags:
 `
 
 var (
-	flags      = flag.NewFlagSet("boot", flag.ContinueOnError)
-	mkdir      = flags.BoolP("mkdir", "m", false, "Create the destination mount path if it doesn't exist")
-	switchRoot = flags.StringP("switch-root", "s", "", "Attempt to switch_root to root filesystem and execute provided init path")
-	procPath   = flags.StringP("cmdline", "c", "/proc/cmdline", "Path to kernel cmdline (default: /proc/cmdline)")
+	flags       = flag.NewFlagSet("boot", flag.ContinueOnError)
+	mkdir       = flags.BoolP("mkdir", "m", false, "Create the destination mount path if it doesn't exist")
+	switchRoot  = flags.StringP("switch-root", "s", "", "Attempt to switch_root to root filesystem and execute provided init path")
+	unshareRoot = flags.StringP("unshare", "u", "", "Attempt to execute init in a namespaced context (container) inside the root filesystem")
+	procPath    = flags.StringP("cmdline", "c", "/proc/cmdline", "Path to kernel cmdline (default: /proc/cmdline)")
 )
 
 const (
@@ -141,7 +143,15 @@ func Run(args []string, verbose bool, noop bool) error {
 				log.Printf("Boot: attempting to switch root to %s with init %s\n", RootPath, *switchRoot)
 			}
 			if !noop {
-				return mount.SwitchRoot(RootPath, *switchRoot)
+				return boot.SwitchRoot(RootPath, *switchRoot)
+			}
+		}
+		if *unshareRoot != "" {
+			if verbose {
+
+			}
+			if !noop {
+				return boot.UnshareRoot(RootPath, *unshareRoot)
 			}
 		}
 	}

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -1,0 +1,23 @@
+package boot
+
+import "log"
+
+// UnshareRoot spawns the image in newRoot as a new container.
+// This is a blocking execution.
+// TODO: add process tracking capabilities, non-blocking execution
+// UnshareRoot is a wrapper for OS specific implementation(s)
+func UnshareRoot(newRoot, init string) error {
+	return unshareRoot(newRoot, init)
+}
+
+// SwitchRoot implements a switch_root to the image in newRoot and Execs init
+// Since this uses Exec, the process is completely taken over by this call, so don't expect a return.
+// SwitchRoot is a wrapper for OS specific implementation(s)
+func SwitchRoot(newRoot, init string) error {
+	return switchRoot(newRoot, init)
+}
+
+// logging should probably have a global context, but this will simplify things for now
+func init() {
+	log.SetPrefix("boot: ")
+}

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -1,6 +1,9 @@
 package boot
 
-import "log"
+import (
+	"log"
+	"os"
+)
 
 // UnshareRoot spawns the image in newRoot as a new container.
 // This is a blocking execution.
@@ -15,6 +18,18 @@ func UnshareRoot(newRoot, init string) error {
 // SwitchRoot is a wrapper for OS specific implementation(s)
 func SwitchRoot(newRoot, init string) error {
 	return switchRoot(newRoot, init)
+}
+
+// PIDInit initializes a PID namespace and execs the provided init
+// It can be called at the begining of any main() function and will only do anythin
+// if the environment indicates that it should.
+func PIDInit() {
+	init := os.Getenv("RBD_INIT")
+	if init == "" {
+		return
+	}
+	pidInit(init)
+	os.Exit(0) // need to stop execution should this return
 }
 
 // logging should probably have a global context, but this will simplify things for now

--- a/pkg/boot/boot_linux.go
+++ b/pkg/boot/boot_linux.go
@@ -265,13 +265,10 @@ func moveRoot(newRoot string) (err error) {
 		return fmt.Errorf("failed to move new root to /: %v", err)
 	}
 	// 4. chroot "."
-	if err = unix.Chroot("."); err != nil {
+	if _, err = chroot("."); err != nil {
 		return fmt.Errorf("failed to change root: %v", err)
 	}
-	// 5. chdir to / (because we're currently stranded)
-	if err = os.Chdir("/"); err != nil {
-		return fmt.Errorf("failed to chdir to /: %v", err)
-	}
+
 	// the dance is done
 	return
 }

--- a/pkg/boot/boot_linux.go
+++ b/pkg/boot/boot_linux.go
@@ -60,7 +60,11 @@ func unshareRoot(newRoot, init string) (err error) {
 	}
 
 	// 6. Exec container
+	log.Print("executing init")
 	c := exec.Command(init)
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
 	if err = c.Run(); err != nil {
 		return fmt.Errorf("clone: failed to start init: %v", err)
 	}

--- a/pkg/boot/boot_linux.go
+++ b/pkg/boot/boot_linux.go
@@ -1,0 +1,300 @@
+package boot
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// we store these as a global var so that we could potentially have a way to update at runtime
+var specialMounts = []string{"/dev", "/proc", "/sys", "/run"}
+
+// unshareRoot starts init in a namespaced context (container)
+// Currently we only do mount + pid namespaces
+func unshareRoot(newRoot, init string) (err error) {
+	log.SetPrefix(log.Prefix() + "clone: ")
+
+	log.Print("starting clone")
+
+	// 0. For a container, we want to be able to launch bare directory containers
+	//    We implement this by bind mounting newRoot on itself.
+	if !isMountpoint(newRoot) {
+		if err = bindMountSelf(newRoot); err != nil {
+			return fmt.Errorf("clone: error: could not self-bind mount bare directory: %v", err)
+		}
+	}
+
+	// 1. Is our image valid?
+	log.Print("validating image")
+	if err = validateImage(newRoot); err != nil {
+		return fmt.Errorf("clone: error: image validation failed: %v", err)
+	}
+
+	// 2. Is our init valid?
+	log.Print("validating init")
+	if err = validateInit(newRoot, init); err != nil {
+		return fmt.Errorf("clone: error: init validationfailed: %v", err)
+	}
+
+	// 3. Create new namespaces
+	log.Printf("creating namespaces")
+	if err = unix.Unshare(syscall.CLONE_NEWNS | syscall.CLONE_NEWPID); err != nil {
+		return fmt.Errorf("clone: failed to unshare namespaces: %v", err)
+	}
+
+	// 4. Do the root moving dance
+	log.Print("preparing image")
+	if err = moveRoot(newRoot); err != nil {
+		return fmt.Errorf("switch_root: error: could not prepare image: %v", err)
+	}
+
+	// 5. Exec container
+	c := exec.Command(init)
+	if err = c.Run(); err != nil {
+		return fmt.Errorf("clone: failed to start init: %v", err)
+	}
+	return
+}
+
+// SwitchRoot performs a switch root into an image
+func switchRoot(newRoot, init string) (err error) {
+	log.SetPrefix(log.Prefix() + "switch_root: ")
+	var oldRoot int
+
+	log.Print("starting switch root")
+
+	// 1. Is our image valid?
+	log.Print("validating image")
+	if err = validateImage(newRoot); err != nil {
+		return fmt.Errorf("switch_root: error: image validation failed: %v", err)
+	}
+
+	// 2. Is our init valid?
+	log.Print("validating init")
+	if err = validateInit(newRoot, init); err != nil {
+		return fmt.Errorf("switch_root: error: init validationfailed: %v", err)
+	}
+
+	// 3. Open old root for later cleanup
+	if oldRoot, err = unix.Open("/", unix.O_DIRECTORY, unix.O_RDONLY); err != nil {
+		return fmt.Errorf("switch_root: error: could not open /: %v", err)
+	}
+	defer unix.Close(oldRoot)
+
+	// 4. Do the root moving dance
+	log.Print("preparing image")
+	if err = moveRoot(newRoot); err != nil {
+		return fmt.Errorf("switch_root: error: could not prepare image: %v", err)
+	}
+
+	// 5. Clean up old root (if its a ramdisk). This is best-effort only.
+	log.Print("cleaning up old root")
+	if isRamdisk(oldRoot) {
+		recursiveDelete(oldRoot)
+	}
+
+	// 6. Exec init
+	log.Print("executing init")
+	if err = unix.Exec(init, []string{init}, []string{}); err != nil {
+		return fmt.Errorf("switch_root: error: exec failed: %v", err)
+	}
+	return
+}
+
+func isRamdisk(fd int) bool {
+	stat := &unix.Statfs_t{}
+	if err := unix.Fstatfs(fd, stat); err != nil {
+		// we don't return errors, but we assume we are *not* a ramdisk
+		return false
+	}
+	if stat.Type == unix.TMPFS_MAGIC || stat.Type == unix.RAMFS_MAGIC {
+		return true
+	}
+	return false
+}
+
+func getDev(fd int) (uint64, error) {
+	stat := &unix.Stat_t{}
+	if err := unix.Fstat(fd, stat); err != nil {
+		return 0, err
+	}
+	return stat.Dev, nil
+}
+
+func isMountpointAt(parentDev uint64, fd int) bool {
+	dev, err := getDev(fd)
+	if err != nil {
+		// note this behavior is slightly arbitrary
+		return false
+	}
+	if dev != parentDev {
+		return true
+	}
+	return false
+}
+
+func isMountpoint(path string) bool {
+	var fd, pfd int
+	var parentDev uint64
+	var err error
+	parent := filepath.Dir(path)
+	if pfd, err = unix.Open(parent, unix.O_DIRECTORY, unix.O_RDONLY); err != nil {
+		// note this behavior is slightly arbitrary
+		return false
+	}
+	defer unix.Close(pfd)
+	if parentDev, err = getDev(pfd); err != nil {
+		return false
+	}
+
+	if fd, err = unix.Open(path, unix.O_DIRECTORY, unix.O_RDONLY); err != nil {
+		return false
+	}
+	defer unix.Close(fd)
+	return isMountpointAt(parentDev, fd)
+}
+
+func validateImage(newRoot string) (err error) {
+	var fd int
+	// Does the directory exist? Or, is it a directory?
+	if fd, err = unix.Open(newRoot, unix.O_DIRECTORY, unix.O_RDONLY); err != nil {
+		return fmt.Errorf("new root is not a valid directory")
+	}
+	unix.Close(fd)
+
+	// Is it a mount point?
+	if !isMountpoint(newRoot) {
+		return fmt.Errorf("new root is not a mountpoint")
+	}
+	return
+}
+
+func validateInit(newRoot, init string) (err error) {
+	var stat os.FileInfo
+	var joined string
+	if joined, err = filepath.EvalSymlinks(filepath.Join(newRoot, init)); err != nil {
+		return fmt.Errorf("init file could not be found")
+	}
+	if stat, err = os.Stat(joined); err != nil {
+		return fmt.Errorf("init file could not be opened")
+	}
+	if !stat.Mode().IsRegular() {
+		return fmt.Errorf("init does not reference a regular file")
+	}
+	if stat.Mode()&0111 == 0 {
+		return fmt.Errorf("init file is not executable")
+	}
+	return
+}
+
+func moveMount(newRoot, mount string) (err error) {
+	joined := filepath.Join(newRoot, mount)
+	if !isMountpoint(mount) {
+		return fmt.Errorf("original mountpoint does not exist")
+	}
+	if isMountpoint(joined) {
+		// we *do* want to unmount at least
+		unix.Unmount(mount, unix.MNT_DETACH)
+		return fmt.Errorf("new mountpoint already mounted, old mount detached")
+	}
+	if err = unix.Mount(mount, joined, "", unix.MS_MOVE, ""); err != nil {
+		// we still force an unmount
+		unix.Unmount(mount, unix.MNT_FORCE)
+		return fmt.Errorf("mount move failed, old mount force unmounted")
+	}
+	return
+}
+
+// this is the workhorse for all schemes
+// it preforms the root-moving dance
+func moveRoot(newRoot string) (err error) {
+	// 1. move special mounts
+	for _, mount := range specialMounts {
+		if err := moveMount(newRoot, mount); err != nil {
+			// this isn't fatal, but we should mention it
+			log.Printf("warn: couldn't move mount %s: %v", mount, err)
+		}
+	}
+	// 2. chdir to new root
+	if err = os.Chdir(newRoot); err != nil {
+		return fmt.Errorf("failed to chdir to new root: %v", err)
+	}
+	// 3. Move newRoot -> /
+	if err = unix.Mount(newRoot, "/", "", unix.MS_MOVE, ""); err != nil {
+		return fmt.Errorf("failed to move new root to /")
+	}
+	// 4. chroot "."
+	if err = unix.Chroot("."); err != nil {
+		return fmt.Errorf("failed to change root")
+	}
+	// 5. chdir to / (because we're currently stranded)
+	if err = os.Chdir("/"); err != nil {
+		return fmt.Errorf("failed to chdir to /")
+	}
+	// the dance is done
+	return
+}
+
+// note: this is best-effort, and doesn't return errors
+//       this is very much by design, since stopping when we hit errors could leave us in strange states
+//       this function is inspired by the one found in u-root
+func recursiveDelete(fd int) {
+	// fd always points to a dir
+	// let's use os instead of writing our own Readdirnames
+	var dev uint64
+	dev, err := getDev(fd)
+	if err != nil {
+		// odd, but just retun
+		return
+	}
+	dir := os.NewFile(uintptr(fd), "__ignored__")
+	names, err := dir.Readdirnames(-1) // does not include . or ..
+	if err != nil {
+		// odd, but just return
+		return
+	}
+	for _, name := range names {
+		if cfd, err := unix.Openat(fd, name, unix.O_DIRECTORY|unix.O_NOFOLLOW, unix.O_RDONLY); err != nil {
+			// this is *not* a directory
+			if err := unix.Unlinkat(fd, name, 0); err != nil {
+				log.Printf("warn: unable to remove file %s: %v", name, err)
+			}
+		} else {
+			// this is a directory
+			if isMountpointAt(dev, cfd) {
+				// we should leave mount points alone, and not descend into them
+				unix.Close(cfd)
+				continue
+			}
+			recursiveDelete(cfd)
+			// recurse done, clean up this dir
+			unix.Close(cfd)
+			if err := unix.Unlinkat(fd, name, 0); err != nil {
+				log.Printf("warn: unable to remove dir %s: %v", name, err)
+			}
+		}
+	}
+
+	return
+}
+
+func bindMountSelf(path string) (err error) {
+	// if we're already a mount point, just return
+	if isMountpoint(path) {
+		return
+	}
+	// we blindly try this without verifying that it's a directory
+	if err = unix.Mount(path, path, "", unix.MS_BIND, ""); err != nil {
+		return fmt.Errorf("failed to create root bind mount: %v", err)
+	}
+	return
+}
+
+func unshareMount() (err error) {
+	return
+}

--- a/pkg/boot/boot_linux.go
+++ b/pkg/boot/boot_linux.go
@@ -25,20 +25,20 @@ func unshareRoot(newRoot, init string) (err error) {
 	//    We implement this by bind mounting newRoot on itself.
 	if !isMountpoint(newRoot) {
 		if err = bindMountSelf(newRoot); err != nil {
-			return fmt.Errorf("clone: error: could not self-bind mount bare directory: %v", err)
+			return fmt.Errorf("clone: could not self-bind mount bare directory: %v", err)
 		}
 	}
 
 	// 1. Is our image valid?
 	log.Print("validating image")
 	if err = validateImage(newRoot); err != nil {
-		return fmt.Errorf("clone: error: image validation failed: %v", err)
+		return fmt.Errorf("clone: image validation failed: %v", err)
 	}
 
 	// 2. Is our init valid?
 	log.Print("validating init")
 	if err = validateInit(newRoot, init); err != nil {
-		return fmt.Errorf("clone: error: init validationfailed: %v", err)
+		return fmt.Errorf("clone: init validationfailed: %v", err)
 	}
 
 	// 3. Create new namespaces
@@ -50,7 +50,7 @@ func unshareRoot(newRoot, init string) (err error) {
 	// 4. Do the root moving dance
 	log.Print("preparing image")
 	if err = moveRoot(newRoot); err != nil {
-		return fmt.Errorf("switch_root: error: could not prepare image: %v", err)
+		return fmt.Errorf("switch_root: could not prepare image: %v", err)
 	}
 
 	// 5. Exec container
@@ -71,25 +71,25 @@ func switchRoot(newRoot, init string) (err error) {
 	// 1. Is our image valid?
 	log.Print("validating image")
 	if err = validateImage(newRoot); err != nil {
-		return fmt.Errorf("switch_root: error: image validation failed: %v", err)
+		return fmt.Errorf("switch_root: image validation failed: %v", err)
 	}
 
 	// 2. Is our init valid?
 	log.Print("validating init")
 	if err = validateInit(newRoot, init); err != nil {
-		return fmt.Errorf("switch_root: error: init validationfailed: %v", err)
+		return fmt.Errorf("switch_root: init validationfailed: %v", err)
 	}
 
 	// 3. Open old root for later cleanup
 	if oldRoot, err = unix.Open("/", unix.O_DIRECTORY, unix.O_RDONLY); err != nil {
-		return fmt.Errorf("switch_root: error: could not open /: %v", err)
+		return fmt.Errorf("switch_root: could not open /: %v", err)
 	}
 	defer unix.Close(oldRoot)
 
 	// 4. Do the root moving dance
 	log.Print("preparing image")
 	if err = moveRoot(newRoot); err != nil {
-		return fmt.Errorf("switch_root: error: could not prepare image: %v", err)
+		return fmt.Errorf("switch_root: could not prepare image: %v", err)
 	}
 
 	// 5. Clean up old root (if its a ramdisk). This is best-effort only.
@@ -101,7 +101,7 @@ func switchRoot(newRoot, init string) (err error) {
 	// 6. Exec init
 	log.Print("executing init")
 	if err = unix.Exec(init, []string{init}, []string{}); err != nil {
-		return fmt.Errorf("switch_root: error: exec failed: %v", err)
+		return fmt.Errorf("switch_root: exec failed: %v", err)
 	}
 	return
 }
@@ -205,7 +205,7 @@ func moveMount(newRoot, mount string) (err error) {
 	if err = unix.Mount(mount, joined, "", unix.MS_MOVE, ""); err != nil {
 		// we still force an unmount
 		unix.Unmount(mount, unix.MNT_FORCE)
-		return fmt.Errorf("mount move failed, old mount force unmounted")
+		return fmt.Errorf("mount move failed, old mount force unmounted: %v", err)
 	}
 	return
 }
@@ -226,15 +226,15 @@ func moveRoot(newRoot string) (err error) {
 	}
 	// 3. Move newRoot -> /
 	if err = unix.Mount(newRoot, "/", "", unix.MS_MOVE, ""); err != nil {
-		return fmt.Errorf("failed to move new root to /")
+		return fmt.Errorf("failed to move new root to /: %v", err)
 	}
 	// 4. chroot "."
 	if err = unix.Chroot("."); err != nil {
-		return fmt.Errorf("failed to change root")
+		return fmt.Errorf("failed to change root: %v", err)
 	}
 	// 5. chdir to / (because we're currently stranded)
 	if err = os.Chdir("/"); err != nil {
-		return fmt.Errorf("failed to chdir to /")
+		return fmt.Errorf("failed to chdir to /: %v", err)
 	}
 	// the dance is done
 	return

--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -1,9 +1,0 @@
-package mount
-
-import "github.com/u-root/u-root/pkg/mount"
-
-// SwitchRoot makes newRootDir the new root directory of the system.
-// Simply wraps u-root/pkg/mount.SwitchRoot
-func SwitchRoot(newRootDir string, init string) error {
-	return mount.SwitchRoot(newRootDir, init)
-}


### PR DESCRIPTION
Closes #19, fixup to correct vendor/modules.txt conflicts in #19 to be able to do a rebase.

This PR does a few things:

- It refactors code related to booting into pkg/boot
- It adds the ability to unshare rather than switch_root, launching in a namespaced context (container)
- It replaces u-root switch_root with native switch_root (since there's a lot of shared code between switch_root and unshare anyway)
