### PR TITLE
krbd: Use a WriteCloser

### DIFF
--- a/internal/cli/boot/boot.go
+++ b/internal/cli/boot/boot.go
@@ -2,6 +2,7 @@ package boot
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"testing/iotest"
@@ -64,7 +65,9 @@ func Run(args []string, verbose bool, noop bool) error {
 
 	mounts := cmdline.Parse(string(procCmdline))
 
-	w, err := krbd.RBDBusAddWriter()
+	wc, err := krbd.RBDBusAddWriter()
+	defer wc.Close()
+	w := wc.(io.Writer)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/rbdmap/rbdmap.go
+++ b/internal/cli/rbdmap/rbdmap.go
@@ -2,6 +2,7 @@ package rbdmap
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"testing/iotest"
@@ -51,7 +52,9 @@ func Run(args []string, verbose bool, noop bool) error {
 		os.Exit(2)
 	}
 
-	w, err := krbd.RBDBusAddWriter()
+	wc, err := krbd.RBDBusAddWriter()
+	defer wc.Close()
+	w := wc.(io.Writer)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/unmap/unmap.go
+++ b/internal/cli/unmap/unmap.go
@@ -3,6 +3,7 @@ package unmap
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"testing/iotest"
@@ -51,7 +52,9 @@ func Run(args []string, verbose bool, noop bool) error {
 		os.Exit(2)
 	}
 
-	w, err := krbd.RBDBusRemoveWriter()
+	wc, err := krbd.RBDBusRemoveWriter()
+	defer wc.Close()
+	w := wc.(io.Writer)
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/boot_linux.go
+++ b/pkg/boot/boot_linux.go
@@ -16,6 +16,7 @@ var specialMounts = []string{"/dev", "/proc", "/sys", "/run"}
 
 // unshareRoot starts init in a namespaced context (container)
 // Currently we only do mount + pid namespaces
+// This should be used iff we intend the current process to be taken over
 func unshareRoot(newRoot, init string) (err error) {
 	log.SetPrefix(log.Prefix() + "clone: ")
 

--- a/pkg/krbd/krbd.go
+++ b/pkg/krbd/krbd.go
@@ -11,7 +11,7 @@ import (
 const sysBusPath = "/sys/bus/rbd"
 
 // RBDBusAddWriter returns an io.Writer with the appropriate sysfs rbd/add opened.
-func RBDBusAddWriter() (io.Writer, error) {
+func RBDBusAddWriter() (io.WriteCloser, error) {
 	rbdBusAddSingleMajor := sysBusPath + "/add_single_major"
 	rbdBusAdd := sysBusPath + "/add"
 
@@ -24,7 +24,7 @@ func RBDBusAddWriter() (io.Writer, error) {
 }
 
 // RBDBusRemoveWriter returns an io.Writer with the appropriate sysfs rbd/remove opened.
-func RBDBusRemoveWriter() (io.Writer, error) {
+func RBDBusRemoveWriter() (io.WriteCloser, error) {
 	rbdBusAddSingleMajor := sysBusPath + "/remove_single_major"
 	rbdBusAdd := sysBusPath + "/remove"
 


### PR DESCRIPTION
Convert `pkg/krbd` to use a WriteCloser instead of a Writer.

Resolves #3